### PR TITLE
Use static favicon URLs for Google Search indexing

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -26,8 +26,6 @@ export const sameAsUrls = [githubUrl, linkedInUrl, twitterUrl] as const;
 
 export const ogImageAlt = 'Lucas Winkler — software developer portfolio';
 
-export const faviconVersion = '20260705';
-
 export const locale = 'en_US';
 
 export const localeLanguage = 'en-US';

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,10 +5,8 @@ import Analytics from '@vercel/analytics/astro';
 import { Font, getImage } from 'astro:assets';
 
 import Seo from '@/components/common/Seo.astro';
-import { faviconVersion, themeColor } from '@/data/site';
+import { themeColor } from '@/data/site';
 import noiseTexture from '@/assets/textures/noise.png';
-
-const faviconHref = (path: string) => `${path}?v=${faviconVersion}`;
 
 interface Props {
   title?: string;
@@ -35,10 +33,10 @@ const noiseTile = await getImage({ src: noiseTexture, format: 'webp' });
 <html lang='en' style={`--noise-tile: url(${noiseTile.src})`}>
   <head>
     <meta charset='utf-8' />
-    <link rel='icon' type='image/png' href={faviconHref('/favicon-96x96.png')} sizes='96x96' />
-    <link rel='icon' type='image/svg+xml' href={faviconHref('/favicon.svg')} />
-    <link rel='icon' href={faviconHref('/favicon.ico')} />
-    <link rel='apple-touch-icon' sizes='180x180' href={faviconHref('/apple-touch-icon.png')} />
+    <link rel='icon' type='image/png' href='/favicon-96x96.png' sizes='96x96' />
+    <link rel='icon' type='image/svg+xml' href='/favicon.svg' />
+    <link rel='shortcut icon' href='/favicon.ico' />
+    <link rel='apple-touch-icon' sizes='180x180' href='/apple-touch-icon.png' />
     <meta name='viewport' content='width=device-width, initial-scale=1' />
     <meta name='theme-color' content={themeColor} />
     <meta name='generator' content={Astro.generator} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes cache-busting query strings from favicon `<link>` tags so Google Search can index stable, permanent icon URLs.

## Changes

- Drop `faviconVersion` and the `faviconHref()` helper from `BaseLayout.astro`
- Use static paths for all favicon links (`/favicon-96x96.png`, `/favicon.svg`, `/favicon.ico`, `/apple-touch-icon.png`)
- Change the `.ico` fallback to `rel="shortcut icon"` per Google's recommended head structure
- Remove the unused `faviconVersion` export from `site.ts`

## Verification

- `npm run build` passes
- Built HTML outputs query-free favicon URLs in the recommended order
- Root `public/favicon.ico` already includes a 48×48 icon alongside 32×32

## Follow-up (manual)

After deploy, request indexing for `https://lucaswinkler.dev` in Google Search Console to queue a favicon recrawl.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62f1fdc8-b016-417a-b6eb-0fe38cbfeb14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62f1fdc8-b016-417a-b6eb-0fe38cbfeb14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

