### PR TITLE
Use static favicon URLs for Google Search indexing

### DIFF
--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -26,8 +26,6 @@ export const sameAsUrls = [githubUrl, linkedInUrl, twitterUrl] as const;
 
 export const ogImageAlt = 'Lucas Winkler — software developer portfolio';
 
-export const faviconVersion = '20260705';
-
 export const locale = 'en_US';
 
 export const localeLanguage = 'en-US';

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,10 +5,8 @@ import Analytics from '@vercel/analytics/astro';
 import { Font, getImage } from 'astro:assets';
 
 import Seo from '@/components/common/Seo.astro';
-import { faviconVersion, themeColor } from '@/data/site';
+import { themeColor } from '@/data/site';
 import noiseTexture from '@/assets/textures/noise.png';
-
-const faviconHref = (path: string) => `${path}?v=${faviconVersion}`;
 
 interface Props {
   title?: string;
@@ -35,10 +33,10 @@ const noiseTile = await getImage({ src: noiseTexture, format: 'webp' });
 <html lang='en' style={`--noise-tile: url(${noiseTile.src})`}>
   <head>
     <meta charset='utf-8' />
-    <link rel='icon' type='image/png' href={faviconHref('/favicon-96x96.png')} sizes='96x96' />
-    <link rel='icon' type='image/svg+xml' href={faviconHref('/favicon.svg')} />
-    <link rel='icon' href={faviconHref('/favicon.ico')} />
-    <link rel='apple-touch-icon' sizes='180x180' href={faviconHref('/apple-touch-icon.png')} />
+    <link rel='icon' type='image/png' href='/favicon-96x96.png' sizes='96x96' />
+    <link rel='icon' type='image/svg+xml' href='/favicon.svg' />
+    <link rel='shortcut icon' href='/favicon.ico' />
+    <link rel='apple-touch-icon' sizes='180x180' href='/apple-touch-icon.png' />
     <meta name='viewport' content='width=device-width, initial-scale=1' />
     <meta name='theme-color' content={themeColor} />
     <meta name='generator' content={Astro.generator} />


### PR DESCRIPTION
Remove cache-busting query strings from favicon link tags and drop the
unused faviconVersion constant. Reorder head markup so the 96x96 PNG is
the primary icon, with SVG and shortcut icon fallbacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated site icon links to use direct, stable file paths.
  * Removed an outdated favicon version reference so icons load consistently across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->