### PR TITLE
Apple design skill audit improvements

### DIFF
--- a/src/components/common/header/NavBar.astro
+++ b/src/components/common/header/NavBar.astro
@@ -14,11 +14,11 @@ const { brandHref = '/#hero', menuId = 'default' } = Astro.props;
 const menuPanelId = `site-header-menu-${menuId}`;
 
 const headerLinkBaseClass =
-  'type-nav select-none py-2 font-medium transition-[opacity,background-color,color] duration-(--duration-quick) ease-(--ease-out)';
+  'type-nav select-none py-2 font-medium transition-[opacity,background-color,color,transform] duration-(--duration-quick) ease-(--ease-out)';
 
 const headerLinkClass = `site-header__link ${headerLinkBaseClass}`;
 const headerIconLinkBaseClass =
-  'type-nav select-none font-medium transition-[opacity,background-color,color] duration-(--duration-quick) ease-(--ease-out)';
+  'type-nav select-none font-medium transition-[opacity,background-color,color,transform] duration-(--duration-quick) ease-(--ease-out)';
 const headerIconLinkClass = `site-header__link ${headerIconLinkBaseClass} site-header__link--icon`;
 const headerMenuLinkClass = `site-header__menu-link ${headerLinkBaseClass} block w-full text-left`;
 
@@ -32,7 +32,7 @@ const menuLinks = [
   <div class='site-header__inner mx-auto flex max-w-full min-h-(--header-inner-min-h) items-center'>
     <a
       href={brandHref}
-      class='site-header__brand type-nav shrink-0 py-2 -mx-1 font-semibold tracking-(--tracking-snug) transition-opacity duration-(--duration-quick) ease-(--ease-out) hover:opacity-80'
+      class='site-header__brand type-nav shrink-0 py-2 -mx-1 font-semibold tracking-(--tracking-snug) transition-[opacity,transform] duration-(--duration-quick) ease-(--ease-out) hover:opacity-80'
       translate='no'>
       {siteName}
     </a>

--- a/src/components/common/header/header.css
+++ b/src/components/common/header/header.css
@@ -55,6 +55,10 @@
   transition: color var(--duration-quick) var(--ease-out);
 }
 
+.site-header__menu-toggle:active .site-header__menu-icon {
+  transform: scale(var(--scale-medium));
+}
+
 .site-header__menu-toggle:focus-visible {
   box-shadow: 0 0 0 2px var(--color-focus-ring-inverse);
 }
@@ -65,6 +69,7 @@
   width: 1em;
   height: 0.625em;
   font-size: var(--text-sm);
+  transition: transform 100ms ease-out;
 }
 
 .site-header__menu-line {
@@ -124,6 +129,8 @@
     var(--color-header-sticky-bg) 50%,
     var(--color-header-sticky-bg-bottom) 100%
   );
+  -webkit-backdrop-filter: blur(var(--header-material-blur)) saturate(var(--header-material-saturate));
+  backdrop-filter: blur(var(--header-material-blur)) saturate(var(--header-material-saturate));
   box-shadow: var(--shadow-header-menu);
   padding-block: var(--header-menu-padding-y);
   padding-inline: var(--header-menu-padding-x);
@@ -157,11 +164,33 @@
   gap: 0.125rem;
 }
 
+.site-header__brand,
+.site-header__link {
+  white-space: nowrap;
+  outline: none;
+  padding-inline: 0.625rem;
+  transition:
+    opacity var(--duration-quick) var(--ease-out),
+    background-color var(--duration-quick) var(--ease-out),
+    color var(--duration-quick) var(--ease-out),
+    transform 100ms ease-out;
+}
+
+.site-header__brand:active,
+.site-header__link:active,
+.site-header__menu-link:active {
+  transform: scale(var(--scale-medium));
+}
+
 .site-header__menu-link {
   border-radius: var(--radius-header-menu-link);
   padding-inline: 0.75rem;
   outline: none;
   white-space: nowrap;
+  transition:
+    color var(--duration-quick) var(--ease-out),
+    background-color var(--duration-quick) var(--ease-out),
+    transform 100ms ease-out;
 }
 
 .site-header__menu-link:focus-visible {
@@ -172,11 +201,13 @@
   transform-origin: top right;
   transform: scale(var(--dropdown-pre-scale));
   opacity: 0;
+  filter: blur(6px);
   pointer-events: none;
   transition:
     transform var(--dropdown-open-dur) var(--dropdown-ease),
-    opacity var(--dropdown-open-dur) var(--dropdown-ease);
-  will-change: transform, opacity;
+    opacity var(--dropdown-open-dur) var(--dropdown-ease),
+    filter var(--dropdown-open-dur) var(--dropdown-ease);
+  will-change: transform, opacity, filter;
 }
 
 .t-dropdown[data-origin='top-right'] {
@@ -186,16 +217,19 @@
 .t-dropdown.is-open {
   transform: scale(1);
   opacity: 1;
+  filter: blur(0);
   pointer-events: auto;
 }
 
 .t-dropdown.is-closing {
   transform: scale(var(--dropdown-closing-scale));
   opacity: 0;
+  filter: blur(4px);
   pointer-events: none;
   transition:
     transform var(--dropdown-close-dur) var(--dropdown-ease),
-    opacity var(--dropdown-close-dur) var(--dropdown-ease);
+    opacity var(--dropdown-close-dur) var(--dropdown-ease),
+    filter var(--dropdown-close-dur) var(--dropdown-ease);
 }
 
 .site-header--hero .site-header__menu-toggle {
@@ -289,6 +323,8 @@
       var(--color-header-sticky-bg) 50%,
       var(--color-header-sticky-bg-bottom) 100%
     );
+    -webkit-backdrop-filter: blur(var(--header-material-blur)) saturate(var(--header-material-saturate));
+    backdrop-filter: blur(var(--header-material-blur)) saturate(var(--header-material-saturate));
     box-shadow: var(--shadow-header-bar);
     opacity: 0;
     transform: scale(var(--header-morph-pre-scale));
@@ -314,6 +350,10 @@
 
   .site-header--hero .site-header__menu-icon {
     transform: translateX(0.375rem);
+  }
+
+  .site-header--hero .site-header__menu-toggle:active .site-header__menu-icon {
+    transform: translateX(0.375rem) scale(var(--scale-medium));
   }
 
   .site-header--hero.is-menu-open .site-header__brand,
@@ -378,13 +418,6 @@
 
 .site-header--sticky .site-header__brand {
   margin-inline: 0;
-}
-
-.site-header__brand,
-.site-header__link {
-  white-space: nowrap;
-  outline: none;
-  padding-inline: 0.625rem;
 }
 
 @media (width >= 40rem) {
@@ -495,6 +528,8 @@
     var(--color-header-sticky-bg) 50%,
     var(--color-header-sticky-bg-bottom) 100%
   );
+  -webkit-backdrop-filter: blur(var(--header-material-blur)) saturate(var(--header-material-saturate));
+  backdrop-filter: blur(var(--header-material-blur)) saturate(var(--header-material-saturate));
   box-shadow: var(--shadow-header-bar);
   padding-inline: var(--header-bar-padding-x);
   padding-block: var(--header-bar-padding-y);
@@ -561,7 +596,30 @@
 
 @media (prefers-reduced-motion: reduce) {
   .t-dropdown {
-    transition: none;
+    filter: none;
+    transition: opacity var(--dropdown-close-dur) ease;
+  }
+
+  .t-dropdown.is-open,
+  .t-dropdown.is-closing {
+    filter: none;
+  }
+
+  .site-header__brand,
+  .site-header__link,
+  .site-header__menu-link,
+  .site-header__menu-icon {
+    transition:
+      opacity var(--duration-quick) ease,
+      background-color var(--duration-quick) ease,
+      color var(--duration-quick) ease;
+  }
+
+  .site-header__brand:active,
+  .site-header__link:active,
+  .site-header__menu-link:active,
+  .site-header__menu-toggle:active .site-header__menu-icon {
+    transform: none;
   }
 
   .site-header__menu-line {

--- a/src/components/sections/ContactCta.astro
+++ b/src/components/sections/ContactCta.astro
@@ -53,7 +53,12 @@ if (!emailLink || !githubLink) {
     white-space: nowrap;
     transition:
       color var(--duration-quick) var(--ease-out),
-      text-decoration-color var(--duration-quick) var(--ease-out);
+      text-decoration-color var(--duration-quick) var(--ease-out),
+      opacity 100ms ease-out;
+  }
+
+  .contact-cta__link:active {
+    opacity: 0.72;
   }
 
   .contact-cta__link :global(svg) {
@@ -71,6 +76,18 @@ if (!emailLink || !githubLink) {
   @media (hover: hover) {
     .contact-cta__link:hover {
       text-decoration-color: currentColor;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .contact-cta__link {
+      transition:
+        color var(--duration-quick) ease,
+        text-decoration-color var(--duration-quick) ease;
+    }
+
+    .contact-cta__link:active {
+      opacity: 1;
     }
   }
 </style>

--- a/src/components/widgets/MotionApproachBridge.tsx
+++ b/src/components/widgets/MotionApproachBridge.tsx
@@ -1,6 +1,6 @@
 import { motion } from 'motion/react';
 
-import { fadeEase, revealGridDuration, revealGridStagger } from '@/lib/motion';
+import { springReveal } from '@/lib/motion';
 import { useScrollReveal } from '@/hooks/use-scroll-reveal';
 
 import type { ApproachItem } from '@/data/approach';
@@ -17,7 +17,7 @@ type MotionApproachCardProps = {
 function MotionApproachCard({ item, index }: MotionApproachCardProps) {
   const reveal = useScrollReveal<HTMLDivElement>({
     y: '0.625rem',
-    transition: { duration: revealGridDuration, ease: fadeEase, delay: index * revealGridStagger },
+    transition: { ...springReveal, delay: index * 0.08 },
   });
 
   return (

--- a/src/components/widgets/MotionExperienceList.tsx
+++ b/src/components/widgets/MotionExperienceList.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'motion/react';
 
 import { formatDateRangeParts, sortReverseChronological, toIsoDate } from '@/lib/experience';
-import { fadeEase, revealItemDuration, revealItemStagger } from '@/lib/motion';
+import { springReveal } from '@/lib/motion';
 import { useScrollReveal } from '@/hooks/use-scroll-reveal';
 
 import type { EducationItem, ExperienceItem } from '@/types/experience';
@@ -41,7 +41,7 @@ function ExperienceRow({
 }: RowProps) {
   const reveal = useScrollReveal<HTMLLIElement>({
     y: '1rem',
-    transition: { duration: revealItemDuration, ease: fadeEase, delay: index * revealItemStagger },
+    transition: { ...springReveal, delay: index * 0.06 },
   });
 
   const leftClassName = 'type-caption m-0 max-w-42 shrink-0 whitespace-nowrap text-text-muted tabular-nums';

--- a/src/components/widgets/MotionExperienceSection.tsx
+++ b/src/components/widgets/MotionExperienceSection.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'motion/react';
 
 import { MotionExperienceList } from '@/components/widgets/MotionExperienceList';
-import { fadeEase, revealSectionDuration } from '@/lib/motion';
+import { springReveal } from '@/lib/motion';
 import { useScrollReveal } from '@/hooks/use-scroll-reveal';
 
 import type { EducationItem, ExperienceItem } from '@/types/experience';
@@ -15,7 +15,7 @@ type MotionExperienceSectionProps = {
 export function MotionExperienceSection({ title, experience, education }: MotionExperienceSectionProps) {
   const headerReveal = useScrollReveal<HTMLDivElement>({
     y: '0.75rem',
-    transition: { duration: revealSectionDuration, ease: fadeEase },
+    transition: springReveal,
   });
 
   return (

--- a/src/components/widgets/MotionFooterWordmark.tsx
+++ b/src/components/widgets/MotionFooterWordmark.tsx
@@ -33,7 +33,9 @@ const OVERSCROLL_LOCK_ARM_PX = 48;
 const OVERSCROLL_LOCK_LOOKAHEAD_MS = 120;
 const OVERSCROLL_LOCK_VELOCITY_ALPHA = 0.5;
 const VIEWPORT_SETTLE_MS = 120;
-const SPRING = { type: 'spring' as const, stiffness: 480, damping: 34, mass: 0.7, bounce: 0 };
+const MOMENTUM_VELOCITY_PX = 180;
+const RELEASE_SPRING = { type: 'spring' as const, stiffness: 480, damping: 34, mass: 0.7, bounce: 0 };
+const RELEASE_MOMENTUM_SPRING = { type: 'spring' as const, stiffness: 420, damping: 26, mass: 0.75, bounce: 0.18 };
 const WHEEL_SMOOTH_SPRING = { type: 'spring' as const, stiffness: 500, damping: 36, mass: 0.55, bounce: 0 };
 
 function clamp(value: number, min: number, max: number): number {
@@ -241,13 +243,21 @@ export function MotionFooterWordmark() {
       overpull.clearLatch();
 
       const baseStretch = stretchFromRawPull(rawPullRef.current);
+      const releaseVelocity = stretchPx.getVelocity();
+      const gestureVelocity = velocityRef.current;
       stretchPx.set(Math.min(stretchPx.get(), baseStretch));
 
       resetPullState();
       isReleasingRef.current = true;
       overpull.clearPull();
 
-      void animate(stretchPx, 0, SPRING).then(() => {
+      const hasMomentum = Math.abs(releaseVelocity) > MOMENTUM_VELOCITY_PX || gestureVelocity > MOMENTUM_VELOCITY_PX;
+      const spring = hasMomentum ? RELEASE_MOMENTUM_SPRING : RELEASE_SPRING;
+
+      void animate(stretchPx, 0, {
+        ...spring,
+        velocity: releaseVelocity,
+      }).then(() => {
         isReleasingRef.current = false;
       });
     };

--- a/src/components/widgets/MotionSelectedWorkSection.tsx
+++ b/src/components/widgets/MotionSelectedWorkSection.tsx
@@ -1,7 +1,7 @@
 import { motion } from 'motion/react';
 
 import { MotionWorkList } from '@/components/widgets/MotionWorkList/MotionWorkList';
-import { fadeEase, revealSectionDuration } from '@/lib/motion';
+import { springReveal } from '@/lib/motion';
 import { useScrollReveal } from '@/hooks/use-scroll-reveal';
 
 import type { SelectedWorkItem } from '@/types/work';
@@ -14,7 +14,7 @@ type MotionSelectedWorkSectionProps = {
 export function MotionSelectedWorkSection({ title, items }: MotionSelectedWorkSectionProps) {
   const headerReveal = useScrollReveal<HTMLDivElement>({
     y: '0.75rem',
-    transition: { duration: revealSectionDuration, ease: fadeEase },
+    transition: springReveal,
   });
 
   return (

--- a/src/components/widgets/MotionWorkList/WorkPanel.tsx
+++ b/src/components/widgets/MotionWorkList/WorkPanel.tsx
@@ -2,7 +2,7 @@ import { LayoutGroup, motion, type Transition } from 'motion/react';
 import { type CSSProperties, type KeyboardEvent, memo, type SyntheticEvent } from 'react';
 
 import { focusVisible } from '@/lib/focus';
-import { fadeEase as fadeEaseBezier } from '@/lib/motion';
+import { springUi } from '@/lib/motion';
 
 import { contentDuration, contentEase, fadeEase, hoverMediaDuration, mediaDuration } from './constants';
 import { panelEndInsetClass, panelGapClass, panelInsetClass, panelShellClass, panelSurfaceClass } from './styles';
@@ -16,9 +16,8 @@ export type WorkPanelProps = {
   index: number;
 };
 
-const logoEnterEase = [0.33, 1, 0.68, 1] as const;
-const logoEnterLayoutTransition = { duration: 0.52, ease: logoEnterEase };
-const logoExitLayoutTransition = { duration: 0.36, ease: fadeEaseBezier };
+const logoEnterLayoutTransition = springUi;
+const logoExitLayoutTransition = { ...springUi, duration: 0.32 } as const;
 
 const logoShellClass =
   'flex items-center justify-center overflow-hidden bg-white rounded-(--radius-work-logo-sm) md:rounded-(--radius-work-logo)';
@@ -234,7 +233,7 @@ export const WorkPanel = memo(function WorkPanel({ item, flexGrow, index }: Work
       aria-expanded={isMobileLayout ? undefined : panelActive}
       aria-labelledby={isExpanded ? `work-${item.id}-title` : undefined}
       aria-label={isExpanded ? undefined : `Show ${item.brand} details`}
-      className={`${panelShellClass} ${isFirst(index) ? panelInsetClass : panelGapClass} ${isLast(index) ? panelEndInsetClass : ''} focus-ring ${isExpanded ? 'cursor-default' : 'cursor-pointer select-none'}`}
+      className={`${panelShellClass} ${isFirst(index) ? panelInsetClass : panelGapClass} ${isLast(index) ? panelEndInsetClass : ''} focus-ring ${isExpanded ? 'cursor-default' : 'cursor-pointer select-none work-panel-shell--pressable'}`}
       style={{ '--panel-grow': flexGrow } as CSSProperties}>
       <div className={panelSurfaceClass} style={panelStyle}>
         <motion.div layoutRoot className='relative h-full w-full overflow-hidden rounded-(--radius-panel)'>

--- a/src/components/widgets/MotionWorkList/work-list.css
+++ b/src/components/widgets/MotionWorkList/work-list.css
@@ -16,6 +16,28 @@
   .work-list .work-panel-shell {
     transition: flex-grow var(--duration-work-panel) var(--ease-out);
   }
+
+  .work-list .work-panel-shell--pressable:active .work-panel {
+    transform: scale(var(--scale-medium));
+  }
+
+  .work-list .work-panel {
+    transition: transform 100ms ease-out;
+  }
+}
+
+@media (width >= 48rem) and (prefers-reduced-motion: reduce) {
+  .work-list .work-panel-shell {
+    transition: none;
+  }
+
+  .work-list .work-panel {
+    transition: none;
+  }
+
+  .work-list .work-panel-shell--pressable:active .work-panel {
+    transform: none;
+  }
 }
 
 @media (width >= 56.25rem) {

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -2,6 +2,15 @@ export const fadeEaseCss = 'cubic-bezier(0.22, 1, 0.36, 1)';
 export const fadeEase = [0.22, 1, 0.36, 1] as const;
 export const noMotion = { duration: 0 } as const;
 
+/** Critically damped UI spring — Apple damping 1.0 / response ~0.4s */
+export const springUi = { type: 'spring' as const, bounce: 0, duration: 0.4 } as const;
+
+/** Momentum / flick spring — slight overshoot only when the gesture carried velocity */
+export const springMomentum = { type: 'spring' as const, bounce: 0.2, duration: 0.4 } as const;
+
+/** Entrance settle — critically damped, slightly longer response */
+export const springReveal = { type: 'spring' as const, bounce: 0, duration: 0.7 } as const;
+
 export const revealSectionDuration = 1.05;
 export const revealGridDuration = 1.05;
 export const revealGridStagger = 0.14;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -98,22 +98,27 @@
   --header-menu-padding-y: 0.3125rem;
   --header-menu-offset: 0.125rem;
   --radius-header-menu-link: max(0px, calc(var(--radius-header-bar) - var(--header-menu-padding-x)));
-  --color-header-sticky-bg: oklch(0.21 0.004 67.659);
-  --color-header-sticky-bg-top: oklch(0.235 0.004 67.659);
-  --color-header-sticky-bg-bottom: oklch(0.185 0.004 67.659);
+  --color-header-sticky-bg: oklch(0.21 0.004 67.659 / 0.72);
+  --color-header-sticky-bg-top: oklch(0.235 0.004 67.659 / 0.78);
+  --color-header-sticky-bg-bottom: oklch(0.185 0.004 67.659 / 0.78);
+  --color-header-sticky-bg-solid: oklch(0.21 0.004 67.659);
+  --color-header-sticky-bg-top-solid: oklch(0.235 0.004 67.659);
+  --color-header-sticky-bg-bottom-solid: oklch(0.185 0.004 67.659);
   --color-header-sticky-text: var(--color-hero-text);
   --color-header-sticky-text-muted: var(--color-hero-text-muted);
-  --color-header-sticky-hover: oklch(1 0 0 / 0.08);
+  --color-header-sticky-hover: oklch(1 0 0 / 0.1);
+  --header-material-blur: 20px;
+  --header-material-saturate: 180%;
   --shadow-header-bar:
-    inset 0 1px 0 0 oklch(1 0 0 / 0.18), inset 0 -1px 0 0 oklch(0.13 0.005 67.659 / 0.55),
-    inset 0 -6px 12px -10px oklch(0.11 0.005 67.659 / 0.28), 0 8px 24px -10px oklch(0.1 0.003 67.55 / 0.24);
+    inset 0 1px 0 0 oklch(1 0 0 / 0.28), inset 0 -1px 0 0 oklch(0.13 0.005 67.659 / 0.4),
+    inset 0 -6px 12px -10px oklch(0.11 0.005 67.659 / 0.22), 0 8px 24px -10px oklch(0.1 0.003 67.55 / 0.28);
   --shadow-header-menu:
-    inset 0 -1px 0 0 oklch(0.13 0.005 67.659 / 0.55), inset 0 -6px 12px -10px oklch(0.11 0.005 67.659 / 0.28),
-    0 8px 24px -10px oklch(0.1 0.003 67.55 / 0.24);
+    inset 0 1px 0 0 oklch(1 0 0 / 0.28), inset 0 -1px 0 0 oklch(0.13 0.005 67.659 / 0.4),
+    inset 0 -6px 12px -10px oklch(0.11 0.005 67.659 / 0.22), 0 8px 24px -10px oklch(0.1 0.003 67.55 / 0.28);
 
   --space-work-panel-inset: 1.5rem;
   --space-work-panel-inset-sm: 1.25rem;
-  --duration-work-panel: 440ms;
+  --duration-work-panel: 400ms;
   --duration-work-media: 380ms;
   --duration-work-content: 330ms;
   --radius-work-logo-target: 0.375rem;
@@ -222,13 +227,29 @@
     html {
       scroll-behavior: auto;
     }
+  }
 
-    *,
-    *::before,
-    *::after {
-      animation-duration: 0.01ms !important;
-      animation-iteration-count: 1 !important;
-      transition-duration: 0.01ms !important;
+  @media (prefers-reduced-transparency: reduce) {
+    :root {
+      --color-header-sticky-bg: var(--color-header-sticky-bg-solid);
+      --color-header-sticky-bg-top: var(--color-header-sticky-bg-top-solid);
+      --color-header-sticky-bg-bottom: var(--color-header-sticky-bg-bottom-solid);
+      --header-material-blur: 0px;
+      --header-material-saturate: 100%;
+    }
+  }
+
+  @media (prefers-contrast: more) {
+    :root {
+      --color-header-sticky-bg: var(--color-header-sticky-bg-solid);
+      --color-header-sticky-bg-top: var(--color-header-sticky-bg-top-solid);
+      --color-header-sticky-bg-bottom: var(--color-header-sticky-bg-bottom-solid);
+      --header-material-blur: 0px;
+      --header-material-saturate: 100%;
+      --color-header-sticky-hover: oklch(1 0 0 / 0.16);
+      --color-border: oklch(0.178 0.003 67.659 / 0.28);
+      --shadow-header-bar: inset 0 0 0 1px oklch(1 0 0 / 0.45), 0 8px 24px -10px oklch(0.1 0.003 67.55 / 0.36);
+      --shadow-header-menu: inset 0 0 0 1px oklch(1 0 0 / 0.45), 0 8px 24px -10px oklch(0.1 0.003 67.55 / 0.36);
     }
   }
 }
@@ -398,11 +419,30 @@
   .type-caption {
     font-size: var(--text-sm);
     line-height: var(--leading-ui);
+    letter-spacing: 0.01em;
   }
 
   .type-nav {
     font-size: var(--text-sm);
     letter-spacing: var(--tracking-nav);
+  }
+
+  .press-feedback {
+    transition: transform 100ms ease-out;
+  }
+
+  .press-feedback:active {
+    transform: scale(var(--scale-medium));
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .press-feedback {
+      transition: none;
+    }
+
+    .press-feedback:active {
+      transform: none;
+    }
   }
 
   .texture-noise-overlay {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Full audit of the portfolio against [emilkowalski/skills apple-design](https://github.com/emilkowalski/skills/blob/main/skills/apple-design/SKILL.md), then targeted improvements that preserve the existing visual language.

### Findings → changes

| Apple principle | Gap | Fix |
| --- | --- | --- |
| **Response** — feedback on pointer-down | Most chrome only reacted on hover/click | Instant `:active` scale on header links, menu toggle, work panels, contact links |
| **Materials & depth** | Sticky header / menu were opaque | Frosted glass via `backdrop-filter` + translucent fills; brighter material edge |
| **Reduced transparency / contrast** | Unsupported | Solid materials + stronger borders when prefs request it |
| **Reduced motion** | Nuclear `* { transition: 0.01ms }` killed useful opacity fades | Removed blanket kill; keep component-level cross-fades |
| **Behavior over animation** | Scroll reveals used fixed tweens | Critically damped springs (`bounce: 0`) for section/list reveals; logo FLIP uses UI spring |
| **Velocity handoff** | Footer overpull release ignored release velocity | Pass live spring velocity; slight bounce only when gesture had momentum |
| **Typography** | Caption tracking flat | Slight positive tracking on small caption text |

### Intentionally unchanged

- Footer rubber-banding / overpull physics (already strong)
- Hero shader + enter choreography (already reduced-motion aware)
- Overall layout, color system, and composition

### Verify

- `pnpm run check:astro`
- `pnpm run check:lint`
- `pnpm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f6a7f44-6fb7-462c-9f74-83a7bc9b749a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f6a7f44-6fb7-462c-9f74-83a7bc9b749a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

