### PR TITLE
Fix selected work cover image resolution for active panels

### DIFF
--- a/src/components/sections/SelectedWork.astro
+++ b/src/components/sections/SelectedWork.astro
@@ -3,12 +3,23 @@ import { getImage } from 'astro:assets';
 
 import { MotionSelectedWorkSection } from '@/components/widgets/MotionSelectedWorkSection';
 import { selectedWork } from '@/data/selected-work';
-import { WORK_COVER_IMAGE_QUALITY } from '@/config/image';
+import { breakpointRem } from '@/lib/breakpoints';
 
 import type { SelectedWorkImage, SelectedWorkItem } from '@/types/work';
 import type { ImageMetadata } from 'astro';
 
-const workImageSizes = '(max-width: 48rem) calc((100vw - 2.5rem) * 1.15), min(42rem, 58vw)';
+const COVER_ASPECT = 16 / 9;
+const COVER_OVERSCAN = 1.1;
+const COVER_ACTIVE_SCALE = 1.045;
+const COVER_SIZE_BUFFER = 1.08;
+const DESKTOP_COVER_FACTOR = COVER_OVERSCAN * COVER_ACTIVE_SCALE * COVER_SIZE_BUFFER;
+const MOBILE_COVER_FACTOR = COVER_OVERSCAN * COVER_SIZE_BUFFER;
+
+const workImageSizes = [
+  `(max-width: ${breakpointRem.md}) calc(max(calc(100vw - 2.5rem), min(56vh, 28rem) * ${COVER_ASPECT}) * ${MOBILE_COVER_FACTOR})`,
+  `(max-width: ${breakpointRem.work}) calc(max(min(36rem, 50vw), min(44vh, 22rem) * ${COVER_ASPECT}) * ${DESKTOP_COVER_FACTOR})`,
+  `calc(max(min(36rem, 50vw), min(52vh, 34rem) * ${COVER_ASPECT}) * ${DESKTOP_COVER_FACTOR})`,
+].join(', ');
 
 async function optimizeCoverImage(src: ImageMetadata): Promise<SelectedWorkImage> {
   const options = {
@@ -16,13 +27,12 @@ async function optimizeCoverImage(src: ImageMetadata): Promise<SelectedWorkImage
     layout: 'constrained' as const,
     fit: 'cover' as const,
     sizes: workImageSizes,
-    quality: WORK_COVER_IMAGE_QUALITY,
   };
 
   const [avif, webp, fallback] = await Promise.all([
     getImage({ ...options, format: 'avif' }),
     getImage({ ...options, format: 'webp' }),
-    getImage({ ...options, format: 'webp', width: 960 }),
+    getImage({ ...options, format: 'webp', width: 1280 }),
   ]);
 
   return {

--- a/src/components/sections/SelectedWork.astro
+++ b/src/components/sections/SelectedWork.astro
@@ -3,11 +3,12 @@ import { getImage } from 'astro:assets';
 
 import { MotionSelectedWorkSection } from '@/components/widgets/MotionSelectedWorkSection';
 import { selectedWork } from '@/data/selected-work';
+import { WORK_COVER_IMAGE_QUALITY } from '@/config/image';
 
 import type { SelectedWorkImage, SelectedWorkItem } from '@/types/work';
 import type { ImageMetadata } from 'astro';
 
-const workImageSizes = '(max-width: 48rem) calc(100vw - 2.5rem), min(36rem, 50vw)';
+const workImageSizes = '(max-width: 48rem) calc((100vw - 2.5rem) * 1.15), min(42rem, 58vw)';
 
 async function optimizeCoverImage(src: ImageMetadata): Promise<SelectedWorkImage> {
   const options = {
@@ -15,12 +16,13 @@ async function optimizeCoverImage(src: ImageMetadata): Promise<SelectedWorkImage
     layout: 'constrained' as const,
     fit: 'cover' as const,
     sizes: workImageSizes,
+    quality: WORK_COVER_IMAGE_QUALITY,
   };
 
   const [avif, webp, fallback] = await Promise.all([
     getImage({ ...options, format: 'avif' }),
     getImage({ ...options, format: 'webp' }),
-    getImage({ ...options, format: 'webp', width: 640 }),
+    getImage({ ...options, format: 'webp', width: 960 }),
   ]);
 
   return {

--- a/src/components/sections/SelectedWork.astro
+++ b/src/components/sections/SelectedWork.astro
@@ -8,18 +8,7 @@ import { breakpointRem } from '@/lib/breakpoints';
 import type { SelectedWorkImage, SelectedWorkItem } from '@/types/work';
 import type { ImageMetadata } from 'astro';
 
-const COVER_ASPECT = 16 / 9;
-const COVER_OVERSCAN = 1.1;
-const COVER_ACTIVE_SCALE = 1.045;
-const COVER_SIZE_BUFFER = 1.08;
-const DESKTOP_COVER_FACTOR = COVER_OVERSCAN * COVER_ACTIVE_SCALE * COVER_SIZE_BUFFER;
-const MOBILE_COVER_FACTOR = COVER_OVERSCAN * COVER_SIZE_BUFFER;
-
-const workImageSizes = [
-  `(max-width: ${breakpointRem.md}) calc(max(calc(100vw - 2.5rem), min(56vh, 28rem) * ${COVER_ASPECT}) * ${MOBILE_COVER_FACTOR})`,
-  `(max-width: ${breakpointRem.work}) calc(max(min(36rem, 50vw), min(44vh, 22rem) * ${COVER_ASPECT}) * ${DESKTOP_COVER_FACTOR})`,
-  `calc(max(min(36rem, 50vw), min(52vh, 34rem) * ${COVER_ASPECT}) * ${DESKTOP_COVER_FACTOR})`,
-].join(', ');
+const workImageSizes = `(max-width: ${breakpointRem.md}) calc(min(56vh, 28rem) * 16 / 9 * 1.15), calc(min(52vh, 34rem) * 16 / 9 * 1.15)`;
 
 async function optimizeCoverImage(src: ImageMetadata): Promise<SelectedWorkImage> {
   const options = {

--- a/src/config/image.ts
+++ b/src/config/image.ts
@@ -1,1 +1,2 @@
 export const OG_IMAGE_QUALITY = 75;
+export const WORK_COVER_IMAGE_QUALITY = 88;

--- a/src/config/image.ts
+++ b/src/config/image.ts
@@ -1,2 +1,1 @@
 export const OG_IMAGE_QUALITY = 75;
-export const WORK_COVER_IMAGE_QUALITY = 88;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Selected work covers looked soft because `sizes` was based on panel **width**, but `object-cover` on tall panels scales 16:9 images to fill **height** — so the browser was under-fetching from `srcset`.

## Fix

Use two `sizes` entries keyed to the panel height clamps from `MotionWorkList` styles:

```
(max-width: 48rem) calc(min(56vh, 28rem) * 16 / 9 * 1.15),
calc(min(52vh, 34rem) * 16 / 9 * 1.15)
```

`1.15` covers overscan (`inset-[-5%]`) and active-state scale (`1.045`). DPR is handled automatically by the browser when picking `srcset` entries.

Fallback `src` width is 1280px.

## Why not more complex?

An earlier version used three breakpoints, `max(panel width, height × aspect)`, and separate buffer constants. Simulation showed identical srcset picks — width never dominates for 16:9 images in these portrait-ish panels, so the simpler height-only form is sufficient.

## Limitation

Sources are 1920×1080, so 3× phones and very tall 2× panels still cap at 1920w.

## Test plan

- [ ] Preview selected work on mobile (2×) and desktop active panel
- [ ] Network tab should show 1280w–1920w variants, not 640w–828w
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a409bff2-5e38-47e8-a963-8e9bc452fcd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a409bff2-5e38-47e8-a963-8e9bc452fcd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

