### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,3 +24,11 @@ astro dev stop | status | logs
 | Section shell       | `src/components/sections/Experience.astro`         |
 | Work carousel       | `src/components/widgets/MotionWorkList/`           |
 | Footer              | `src/components/sections/Footer.astro`             |
+
+## Cursor Cloud specific instructions
+
+Static Astro (SSG) portfolio, no backend/DB/env vars. Standard scripts live in `package.json` (`dev`, `build`, `check`, `fix`); `pnpm dev` serves on `http://localhost:4321`.
+
+- Node must be **24.x** (`.nvmrc` / engines). The VM's default `node` on `PATH` is v22; `~/.bashrc` is configured to prepend nvm's Node 24 so interactive shells and the update script use it. If `node -v` ever shows v22, run `nvm use` (reads `.nvmrc`) first.
+- Package manager is **pnpm 10.33.3** via corepack (the lockfile is pnpm v9.0 format). Running `pnpm` may print an "update available → 11.x" notice; ignore it and stay on 10.33.3 to keep the lockfile stable.
+- `pnpm build` runs `astro check` then builds; image optimization (sharp) of the hero image makes the build take ~50s. This is normal, not a hang.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Astro portfolio in Cursor Cloud and documents the non-obvious startup caveats for future agents.

- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering the Node 24 vs. VM-default Node 22 `PATH` gotcha, pinning pnpm to 10.33.3 via corepack (lockfile is v9.0), and the expected ~50s build due to sharp image optimization.

No application code was changed.

## Environment

- Node **24.15.0** via nvm (`.nvmrc`), pnpm **10.33.3** via corepack.
- Update script installs Node from `.nvmrc`, activates pnpm 10.33.3, and runs `pnpm install`.

## Verification

- `pnpm install` — clean install (esbuild/sharp builds allowed).
- `pnpm check` — astro check, eslint, prettier all pass.
- `pnpm build` — static build succeeds (2 pages, 76 optimized images).
- `pnpm dev` — serves `http://localhost:4321` (HTTP 200); homepage, smooth-scroll nav, work carousel, and footer verified in-browser.

[astro_portfolio_dev_walkthrough.mp4](https://cursor.com/agents/bc-db211f1b-9d66-478c-bee5-2265446de1a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_portfolio_dev_walkthrough.mp4)

[Homepage hero](https://cursor.com/agents/bc-db211f1b-9d66-478c-bee5-2265446de1a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhero_home.webp)
[Selected Work carousel](https://cursor.com/agents/bc-db211f1b-9d66-478c-bee5-2265446de1a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fselected_work.webp)
[Footer](https://cursor.com/agents/bc-db211f1b-9d66-478c-bee5-2265446de1a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffooter.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db211f1b-9d66-478c-bee5-2265446de1a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db211f1b-9d66-478c-bee5-2265446de1a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added local development guidance covering the required Node.js and pnpm versions.
  * Documented build behavior, including validation checks and potential image optimization delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->