### PR TITLE
Fix horizontal overflow in Selected Work carousel

### DIFF
--- a/src/components/widgets/MotionWorkList/styles.ts
+++ b/src/components/widgets/MotionWorkList/styles.ts
@@ -1,11 +1,11 @@
 export const panelShellClass =
-  'work-panel-shell relative isolate min-w-0 shrink-0 rounded-(--radius-panel) snap-start flex-[0_0_calc(100vw-2*var(--section-padding-x))] md:snap-none md:[flex:var(--panel-grow)_1_0]';
+  'work-panel-shell relative isolate min-w-0 shrink-0 rounded-(--radius-panel) snap-start flex-[0_0_calc(100%-2*var(--section-padding-x))] md:snap-none md:[flex:var(--panel-grow)_1_0]';
 
 export const panelSurfaceClass =
   'work-panel relative h-full w-full overflow-hidden rounded-(--radius-panel) shadow-(--shadow-panel) [contain:layout_style]';
 
 export const listClass =
-  '@container work-list flex h-[clamp(20rem,56vh,28rem)] w-screen max-w-none select-none gap-0 py-1 [contain:layout] [margin-inline:calc(50%-50vw)] snap-x snap-proximity [scroll-padding-inline:var(--section-padding-x)] overflow-x-auto [overflow-anchor:none] [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden md:h-[clamp(16rem,44vh,22rem)] md:w-full md:gap-2 md:py-0 md:[margin-inline:0] md:snap-none md:overflow-visible md:[scroll-padding-inline:0] work:h-[clamp(18rem,52vh,34rem)]';
+  '@container work-list flex h-[clamp(20rem,56vh,28rem)] w-[calc(100%+2*var(--section-padding-x))] max-w-none select-none gap-0 py-1 [contain:layout] [margin-inline:calc(-1*var(--section-padding-x))] snap-x snap-proximity [scroll-padding-inline:var(--section-padding-x)] overflow-x-auto [overflow-anchor:none] [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden md:h-[clamp(16rem,44vh,22rem)] md:w-full md:gap-2 md:py-0 md:[margin-inline:0] md:snap-none md:overflow-visible md:[scroll-padding-inline:0] work:h-[clamp(18rem,52vh,34rem)]';
 
 export const panelInsetClass = 'ms-(--section-padding-x) md:ms-0';
 export const panelGapClass = 'ms-2 md:ms-0';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Below the `md` breakpoint (48rem / 768px), the Selected Work carousel used a full-bleed layout with `w-screen` and `margin-inline: calc(50% - 50vw)`. On many browsers, `100vw` includes the vertical scrollbar gutter, so the work list ends up slightly wider than the visible page and triggers a horizontal scrollbar.

## Fix

Replace viewport-unit sizing with percentage-based breakout relative to the section inner width:

- **List:** `w-[calc(100%+2*var(--section-padding-x))]` with `margin-inline: calc(-1*var(--section-padding-x))`
- **Panels:** `flex-basis: calc(100% - 2*var(--section-padding-x))`

This preserves the same full-bleed visual and carousel behavior without relying on `100vw`.

## Notes

- No interaction or layout behavior changes at `md` and above.
- Mobile snap scrolling, panel sizing, and insets are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b77ec33-d5fd-4d74-9a23-08a9c3e444be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b77ec33-d5fd-4d74-9a23-08a9c3e444be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

