### PR TITLE
Fix selected work cover image resolution for active panels (#15)

### DIFF
--- a/src/components/sections/SelectedWork.astro
+++ b/src/components/sections/SelectedWork.astro
@@ -3,11 +3,12 @@ import { getImage } from 'astro:assets';
 
 import { MotionSelectedWorkSection } from '@/components/widgets/MotionSelectedWorkSection';
 import { selectedWork } from '@/data/selected-work';
+import { breakpointRem } from '@/lib/breakpoints';
 
 import type { SelectedWorkImage, SelectedWorkItem } from '@/types/work';
 import type { ImageMetadata } from 'astro';
 
-const workImageSizes = '(max-width: 48rem) calc(100vw - 2.5rem), min(36rem, 50vw)';
+const workImageSizes = `(max-width: ${breakpointRem.md}) calc(min(56vh, 28rem) * 16 / 9 * 1.15), calc(min(52vh, 34rem) * 16 / 9 * 1.15)`;
 
 async function optimizeCoverImage(src: ImageMetadata): Promise<SelectedWorkImage> {
   const options = {
@@ -20,7 +21,7 @@ async function optimizeCoverImage(src: ImageMetadata): Promise<SelectedWorkImage
   const [avif, webp, fallback] = await Promise.all([
     getImage({ ...options, format: 'avif' }),
     getImage({ ...options, format: 'webp' }),
-    getImage({ ...options, format: 'webp', width: 640 }),
+    getImage({ ...options, format: 'webp', width: 1280 }),
   ]);
 
   return {


### PR DESCRIPTION
* Fix selected work cover image quality regression

The image optimization commit introduced aggressive WebP/AVIF compression and undersized `sizes` hints relative to the panel's overscan and scale transform. Restore visual fidelity by setting explicit quality (88), increasing fallback width to 960px, and sizing for the actual rendered area.

* Fix work cover sizes for object-cover and active panel scale

The sizes hint was based on panel width, but 16:9 covers in tall panels render much wider due to object-cover (driven by panel height). Browsers multiply sizes by devicePixelRatio automatically when picking srcset entries, so sizes only needs the CSS-pixel rendered width.

Use per-breakpoint sizes derived from max(panel width, panel height * aspect ratio), including overscan and active-state scale.

* Simplify work cover sizes to two height-based expressions

The three-tier max(width, height × aspect) setup matched layout exactly but was more complex than needed. For 16:9 covers in these tall panels, height always drives object-cover, so two sizes entries suffice.

---------